### PR TITLE
Updated Prettier to version 1.8.2

### DIFF
--- a/src/NodeProcess.cs
+++ b/src/NodeProcess.cs
@@ -8,7 +8,7 @@ namespace JavaScriptPrettier
 {
     internal class NodeProcess
     {
-        public const string Packages = "prettier@1.4.2";
+        public const string Packages = "prettier@1.8.2";
 
         private static string _installDir = Path.Combine(Path.GetTempPath(), Vsix.Name, Packages.GetHashCode().ToString());
         private static string _executable = Path.Combine(_installDir, "node_modules\\.bin\\prettier.cmd");


### PR DESCRIPTION
The latest version of Prettier is at the time of writing 1.8.2

It adds a lot of support and fixes for both JS and TypeScript formatting and adds some things needed to making custom configuration possible. (coming in another Pull Request later)