### PR TITLE
Configuration and parser hinting

### DIFF
--- a/src/Commands/CommandRegistration.cs
+++ b/src/Commands/CommandRegistration.cs
@@ -35,7 +35,7 @@ namespace JavaScriptPrettier
             ITextBufferUndoManager undoManager = UndoProvider.GetTextBufferUndoManager(view.TextBuffer);
             NodeProcess node = view.Properties.GetOrCreateSingletonProperty(() => new NodeProcess());
 
-            AddCommandFilter(textViewAdapter, new PrettierCommand(view, undoManager, node, doc.Encoding));
+            AddCommandFilter(textViewAdapter, new PrettierCommand(view, undoManager, node, doc.Encoding, doc.FilePath));
 
             if (!node.IsReadyToExecute())
             {

--- a/src/Commands/PrettierCommand.cs
+++ b/src/Commands/PrettierCommand.cs
@@ -58,10 +58,7 @@ namespace JavaScriptPrettier
             {
                 edit.Replace(0, _view.TextBuffer.CurrentSnapshot.Length, output);
                 edit.Apply();
-
-                var dte = (DTE)ServiceProvider.GlobalProvider.GetService(typeof(DTE));
-                dte.ExecuteCommand("Edit.FormatDocument");
-
+                
                 undo.Complete();
             }
 

--- a/src/Commands/PrettierCommand.cs
+++ b/src/Commands/PrettierCommand.cs
@@ -21,13 +21,15 @@ namespace JavaScriptPrettier
         private ITextBufferUndoManager _undoManager;
         private NodeProcess _node;
         private Encoding _encoding;
+        private string _filePath;
 
-        public PrettierCommand(IWpfTextView view, ITextBufferUndoManager undoManager, NodeProcess node, Encoding encoding)
+        public PrettierCommand(IWpfTextView view, ITextBufferUndoManager undoManager, NodeProcess node, Encoding encoding, string filePath)
         {
             _view = view;
             _undoManager = undoManager;
             _node = node;
             _encoding = encoding;
+            _filePath = filePath;
         }
 
         public override int Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
@@ -48,7 +50,7 @@ namespace JavaScriptPrettier
         private async Task<bool> MakePrettier()
         {
             string input = _view.TextBuffer.CurrentSnapshot.GetText();
-            string output = await _node.ExecuteProcess(input, _encoding);
+            string output = await _node.ExecuteProcess(input, _encoding, _filePath);
 
             if (string.IsNullOrEmpty(output) || input == output)
                 return false;

--- a/src/NodeProcess.cs
+++ b/src/NodeProcess.cs
@@ -8,7 +8,7 @@ namespace JavaScriptPrettier
 {
     internal class NodeProcess
     {
-        public const string Packages = "prettier@1.4.2";
+        public const string Packages = "prettier@1.8.2";
 
         private static string _installDir = Path.Combine(Path.GetTempPath(), Vsix.Name, Packages.GetHashCode().ToString());
         private static string _executable = Path.Combine(_installDir, "node_modules\\.bin\\prettier.cmd");

--- a/src/NodeProcess.cs
+++ b/src/NodeProcess.cs
@@ -80,12 +80,14 @@ namespace JavaScriptPrettier
             }
         }
 
-        public async Task<string> ExecuteProcess(string input, Encoding encoding)
+        public async Task<string> ExecuteProcess(string input, Encoding encoding, string filePath)
         {
             if (!await EnsurePackageInstalled())
                 return null;
 
-            var start = new ProcessStartInfo("cmd", $"/c \"{_executable}\" --stdin")
+            var command = $"/c \"\"{_executable}\" --stdin-filepath \"{filePath}\" --stdin\"";
+
+            var start = new ProcessStartInfo("cmd", command)
             {
                 UseShellExecute = false,
                 CreateNoWindow = true,


### PR DESCRIPTION
Prettier has a `--stdin-filepath` argument that works wonders:

1. It selects the correct parser according to the filename - so TypeScript works alot better.
2. It looks for Prettier configuration files according to their [configuration pattern](https://prettier.io/docs/en/configuration.html). So people can use the configuration file that the VSCode extension uses and such.

I have also removed the Visual Studio formatting after the Prettier command. I'm not sure if you like that change - but it can be very confusing if you change the default tab size, and then Visual Studio goes in and reverts that to it's own formatting. We can add it back in if you like.

This matched with Pull Request #14 should fix:

#12 
#8 
#4 

But I haven't had time to really test each of them.