### PR TITLE
Update Prettier to version 1.12.1

### DIFF
--- a/src/NodeProcess.cs
+++ b/src/NodeProcess.cs
@@ -8,7 +8,7 @@ namespace JavaScriptPrettier
 {
     internal class NodeProcess
     {
-        public const string Packages = "prettier@1.8.2";
+        public const string Packages = "prettier@1.11.1";
 
         private static string _installDir = Path.Combine(Path.GetTempPath(), Vsix.Name, Packages.GetHashCode().ToString());
         private static string _executable = Path.Combine(_installDir, "node_modules\\.bin\\prettier.cmd");

--- a/src/NodeProcess.cs
+++ b/src/NodeProcess.cs
@@ -8,7 +8,7 @@ namespace JavaScriptPrettier
 {
     internal class NodeProcess
     {
-        public const string Packages = "prettier@1.11.1";
+        public const string Packages = "prettier@1.12.1";
 
         private static string _installDir = Path.Combine(Path.GetTempPath(), Vsix.Name, Packages.GetHashCode().ToString());
         private static string _executable = Path.Combine(_installDir, "node_modules\\.bin\\prettier.cmd");


### PR DESCRIPTION
This updates JavaScriptPrettier to the current release of prettier.

This is un-tested - I was going to let your setup of AppVeyor do the build for me (it looks like it will build pull-requests?). I'll update this PR once I've tried out the vsix.