### PR TITLE
Fixed 2 bugs related to #6

### DIFF
--- a/src/Commands/PrettierCommand.cs
+++ b/src/Commands/PrettierCommand.cs
@@ -67,7 +67,8 @@ namespace JavaScriptPrettier
                 undo.Complete();
             }
 
-            var newSnapshotPoint = new SnapshotPoint(_view.TextBuffer.CurrentSnapshot, snapshotPoint.Position.Position);
+            var currSnapShot = _view.TextBuffer.CurrentSnapshot;
+            var newSnapshotPoint = new SnapshotPoint(currSnapShot, Math.Min(snapshotPoint.Position.Position, currSnapShot.Length));
             _view.Caret.MoveTo(newSnapshotPoint);
             _view.ViewScroller.EnsureSpanVisible(new SnapshotSpan(newSnapshotPoint, 0));
 

--- a/src/RunningDocTableEventsHandler.cs
+++ b/src/RunningDocTableEventsHandler.cs
@@ -47,8 +47,8 @@ namespace JavaScriptPrettier
                         return VSConstants.S_OK;
                     }
 
-                    PrettierCommand cmd = wpfTextView.Properties.GetProperty<PrettierCommand>("prettierCommand");
-                    if (cmd != null)
+                    PrettierCommand cmd;
+                    if (wpfTextView.Properties.TryGetProperty<PrettierCommand>("prettierCommand", out cmd))
                     {
                         ThreadHelper.JoinableTaskFactory.Run(() => cmd.MakePrettierAsync());
                     }


### PR DESCRIPTION
Fixed error throw when saving a non-supported file type
Fixed throw when the current cursor position is greater that the resulting reformatted file length