### PR TITLE
Allow request of specific Prettier version for embedded usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - [ ] Move strings to resource file
 - [ ] Execute on document save
 - [ ] Execute on document format
-- [ ] Use your own version of Prettier
 
 Features that have a checkmark are complete and available for
 download in the
@@ -14,6 +13,9 @@ download in the
 
 These are the changes to each version that has been released
 on the official Visual Studio extension gallery.
+
+## 2.2
+- [x] Ability to request a specific version of Prettier for embedded execution.
 
 ## 2.1
 - [x] Ability to use a locally installed prettier version before using internal version

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the [change log](CHANGELOG.md) for changes and road map.
 
 - Prettifies JavaScript or TypeScript files
 - Uses [Prettier](https://github.com/jlongster/prettier) node module
-    - If a version of Prettier can be found in installed via npm relative to the current file, it will be used.
+    - If a version of Prettier can be found installed via npm locally (relative to the current file), it will be used.
     - If no local Prettier installation is found, the extension falls back to an embedded Prettier.
 - Reads the standard [Prettier configuration file](https://prettier.io/docs/en/configuration.html)
 
@@ -75,15 +75,15 @@ Here is an example containing the two most common settings that people want to c
 [Read more about Prettier configuration options here.](https://prettier.io/docs/en/options.html)
 
 #### Settings
-Access extension settings at Tools >>> Options, Prettier.
+Access extension settings within Visual Studio via Tools >>> Options, Prettier.
 
 1. Format on Save
     * If true, run Prettier whenever a JavaScript file is saved.
-    * (Try setting to true. This is where the magic happens!)
+    * (Try setting to true. This is where the magic happens, instantly snapping your code into place! Never fret with whitespace again!)
 2. Prettier version for embedded usage: 
     * If your solution does not have a local version of Prettier installed via npm, the extension will attempt to download and use the version noted here.
-    * Extension will download a requested version once and reuse that now embedded Prettier install.
-    * If the version declared cannot be found via npm, the setting will revert to 2.2.1, a known good Prettier version.
+    * Extension will download a requested version once and reuse that now embedded Prettier install until the setting requests another version.
+    * If the version declared cannot be found via npm, the extension will revert to 2.2.1, a known good Prettier version.
     * NOTE: To preserve legacy behavior, note that previous 2.x versions of this extension used Prettier 1.12.1.
 
 #### Can it use my bundled version of Prettier?

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ See the [change log](CHANGELOG.md) for changes and road map.
 ## Features
 
 - Prettifies JavaScript or TypeScript files
-- Uses [prettier](https://github.com/jlongster/prettier) node module (uses local version or falls back to plugin version)
-- Reads the standard [prettier configuration file](https://prettier.io/docs/en/configuration.html)
+- Uses [Prettier](https://github.com/jlongster/prettier) node module
+    - If a version of Prettier can be found in installed via npm relative to the current file, it will be used.
+    - If no local Prettier installation is found, the extension falls back to an embedded Prettier.
+- Reads the standard [Prettier configuration file](https://prettier.io/docs/en/configuration.html)
 
 ### Prettify
-This extension calls the [prettier](https://github.com/jlongster/prettier) node module behind the scenes to format any JavaScript document to its standards.
+This extension calls the [Prettier](https://github.com/jlongster/prettier) node module behind the scenes to format any JavaScript document to its standards.
 
 For example, take the following code:
 
@@ -53,10 +55,15 @@ Invoke the command from the context menu in the JavaScript editor.
 
 #### Updating from 1.1 to 2.0
 Depending on your Visual Studio Configuration, you might experience that 2.0's output differs from the one you got with 1.1.  
+
 Most likely it is the tab size that has been changed from 4 spaces to 2. Please read the configuration section below on details how to get 4 spaces as tabsize.
 
-#### Configuration
-It is quite easy to setup Prettier to format alittle bit different. Like having 4 spaces instead of 2 spaces. The easiest way is to create a `.prettierrc` in your project root. Here is an example containing the two most common settings that people want to change: `tabWidth` is how many spaces it uses for indentation, and `printWidth` is how long a line can be before it breaks down:
+#### Configuration via .prettierrc
+It is quite easy to setup Prettier to format a little bit differently, like having 4 spaces instead of 2 spaces per tab. 
+
+The easiest way is to [create a `.prettierrc`](https://prettier.io/docs/en/configuration.html) file in your project root. 
+
+Here is an example containing the two most common settings that people want to change: `tabWidth` is how many spaces it uses for indentation, and `printWidth` is how long a line can be before it breaks down:
 
 ```json
   {
@@ -65,10 +72,24 @@ It is quite easy to setup Prettier to format alittle bit different. Like having 
   }
 ```
 
-[Read more about the configuration file here](https://prettier.io/docs/en/configuration.html)
+[Read more about Prettier configuration options here.](https://prettier.io/docs/en/options.html)
 
-#### Can it use my bundled version of prettier?
-Yes, the plugin will search for a locally installed prettier version before falling back to its own version.
+#### Settings
+Access extension settings at Tools >>> Options, Prettier.
+
+1. Format on Save
+    * If true, run Prettier whenever a JavaScript file is saved.
+    * (Try setting to true. This is where the magic happens!)
+2. Prettier version for embedded usage: 
+    * If your solution does not have a local version of Prettier installed via npm, the extension will attempt to download and use the version noted here.
+    * Extension will download a requested version once and reuse that now embedded Prettier install.
+    * If the version declared cannot be found via npm, the setting will revert to 2.2.1, a known good Prettier version.
+    * NOTE: To preserve legacy behavior, note that previous 2.x versions of this extension used Prettier 1.12.1.
+
+#### Can it use my bundled version of Prettier?
+Yes, the plugin will search for a locally (relative to the open file) installed Prettier version before falling back to its own version. 
+
+It does ***not*** currently support using a globally installed version of Prettier, and will use its embedded version instead.
 
 ## Contribute
 Check out the [contribution guidelines](.github/CONTRIBUTING.md)

--- a/src/Commands/CommandRegistration.cs
+++ b/src/Commands/CommandRegistration.cs
@@ -32,17 +32,11 @@ namespace JavaScriptPrettier
                 return;
 
             ITextBufferUndoManager undoManager = UndoProvider.GetTextBufferUndoManager(view.TextBuffer);
-            NodeProcess node = view.Properties.GetOrCreateSingletonProperty(() => new NodeProcess());
 
-            var cmd = new PrettierCommand(view, undoManager, node, doc.Encoding, doc.FilePath);
+            var cmd = new PrettierCommand(view, undoManager, doc.Encoding, doc.FilePath);
             view.Properties.AddProperty("prettierCommand", cmd);
 
             AddCommandFilter(textViewAdapter, cmd);
-
-            if (!node.IsReadyToExecute())
-            {
-                node.EnsurePackageInstalledAsync().ConfigureAwait(false);
-            }
         }
         private void AddCommandFilter(IVsTextView textViewAdapter, BaseCommand command)
         {

--- a/src/Commands/PrettierCommand.cs
+++ b/src/Commands/PrettierCommand.cs
@@ -22,13 +22,14 @@ namespace JavaScriptPrettier
         private readonly Encoding _encoding;
         private readonly string _filePath;
 
-        public PrettierCommand(IWpfTextView view, ITextBufferUndoManager undoManager, NodeProcess node, Encoding encoding, string filePath)
+        public PrettierCommand(IWpfTextView view, ITextBufferUndoManager undoManager, Encoding encoding, string filePath)
         {
             _view = view;
             _undoManager = undoManager;
-            _node = node;
             _encoding = encoding;
             _filePath = filePath;
+
+            _node = PrettierPackage._node;
         }
 
         public override int Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="J1da7ad9e-85b3-4a0c-8e45-b2ae59a575a7" Version="2.1" Language="en-US" Publisher="Mads Kristensen" />
+        <Identity Id="J1da7ad9e-85b3-4a0c-8e45-b2ae59a575a7" Version="2.2" Language="en-US" Publisher="Mads Kristensen" />
         <DisplayName>JavaScript Prettier</DisplayName>
         <Description xml:space="preserve">Prettier is an opinionated JavaScript formatter inspired by refmt with advanced support for language features from ES2017, JSX, and Flow. It removes all original styling and ensures that all outputted JavaScript conforms to a consistent style.</Description>
         <MoreInfo>https://github.com/madskristensen/JavaScriptPrettier</MoreInfo>


### PR DESCRIPTION
This PR adds a setting, "Prettier version for embedded usage" (`EmbeddedVersion`), to `OptionPageGrid`, and then uses that string to determine what version of Prettier to download, call, and reuse during execution.

This was done to help those whose project lacks a local Prettier, perhaps in an es5 codebase that doesn't require transpilation or other npm requirements, update their version of Prettier in Visual Studio to match any team requirements that may assume another tooling, a situation I might find myself in currently (some use VS Code & Prettier, other team members are only familiar with Visual Studio proper). 

> Prettier v2.0+ [notoriously breaks backwards compatibility without an override setting](https://github.com/prettier/prettier/issues/7972) for a space between `function` and `(` in anonymous functions, for example.

Another option would be to allow the use of a globally installed Prettier, but for those unfamiliar with npm adding a setting for requesting any Prettier version for embedded use seemed to be the most expedient path.

Invalid strings that produce [the `code ETARGET` error](https://stackoverflow.com/q/32948161/1028230) are replaced with 2.2.1, a known good and currently latest version of Prettier. The original value for this setting, however, is 1.12.1, matching the version used by this extension's v2.0 and v2.1, ensuring that shops that have standardized on Prettier 1.x do not suddenly deal with breaking changes on extension upgrade.

Related documentation (README, CHANGELOG, and vsixmanifest) also changed to include version bump and description of the new feature. README also edited slightly for content and readability.

-----------------

### Note/Admission/Mea culpa

I was unable to quickly find a better way to get `OptionPageGrid.EmbeddedVersion` to the `NodeProcess` constructor. 

`CommandRegistration` didn't smell like the best place to set up a `NodeProcess` singleton, so I moved the setup to `PrettierPackage`. By not awaiting the `EnsurePackageInstalledAsync`, I believe I've avoided further compromising the setup thread in any actionable way. But, again, getting `OptionPageGrid.EmbeddedVersion` to the `NodeProcess` constructor eluded me and I used the painful `static` hack to achieve something similar.

I did try shoehorning in the context a few different ways, but failed. I also walked through the Sticky Christmas video to see how you used the options setup following the lead of the [Visual Studio Extensibility Samples Options example](https://github.com/microsoft/VSSDK-Extensibility-Samples/tree/master/Options/src/Options). I don't believe I can use [the `.Instance.[PropertyName]` construction you have in Sticky Christmas](https://www.youtube.com/watch?v=EniQmgmMb6o&t=59m45s) without churning `OptionPageGrid` significantly, and wanted to PR this "works but with [broken windows](https://blog.codinghorror.com/the-broken-window-theory/)" version before I let the perfect get in the way of the potentially good enough -- and before I rabbit-holed another weekend to try and find a better solution as a green extensions programmer. 

Am I hoping you might suggest The Right Way to do this so that I can avoid the rabbit hole? Yes, yes I am. ;^D But, honestly, it does work as-is fairly well as far as I can tell, though the window's broken, solves our immediately problem afaict, and thought it was worth PRing.